### PR TITLE
Update hello_ch04.ts

### DIFF
--- a/Chapter04/hello_ch04.ts
+++ b/Chapter04/hello_ch04.ts
@@ -133,7 +133,7 @@ function auditLogDec(target: any,
         originalFunction.apply(this, arguments);
     }
     
-    target[methodName] = auditFunction;
+    descriptor.value = auditFunction;
 }
 
 class ClassWithAuditDec {


### PR DESCRIPTION
Method Decorator function must return either undefined, the provided property descriptor, or a new property descriptor.
Returning undefined is equivalent to returning the provided property descriptor.
So, this changed provided property descriptor.